### PR TITLE
feat/opencl: getContextInfo implementation

### DIFF
--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -76,11 +76,16 @@ impl API {
                             },
                             cl::ContextInfoQuery::DEVICES => {
                                 let len = *info_size / size_of::<cl::uint>();
-                                Ok(ContextInfo::Devices(
-                                    Vec::from_raw_parts(
+                                let dev_ids = Vec::from_raw_parts(
                                         info_ptr as *mut cl::uint,
                                         len, len
-                                )))
+                                );
+                                Ok(ContextInfo::Devices(
+                                    dev_ids
+                                        .iter()
+                                        .map(|&id| Device::from_isize(id as isize))
+                                        .collect()
+                                ))
                             },
                             cl::ContextInfoQuery::NUM_DEVICES => {
                                 Ok(ContextInfo::NumDevices(info_ptr as cl::uint))

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -3,7 +3,8 @@
 //! At Coaster device can be understood as a synonym to OpenCL's context.
 
 use libc;
-use frameworks::opencl::{API, Error, Device};
+use frameworks::opencl::{API, Device, Error};
+use frameworks::opencl::context::ContextInfo;
 use super::types as cl;
 use super::ffi::*;
 use std::ptr;
@@ -56,7 +57,7 @@ impl API {
     pub fn get_context_info(
         context: cl::context_id,
         info: cl::ContextInfoQuery,
-    ) -> Result<cl::ContextInfo, Error> {
+    ) -> Result<ContextInfo, Error> {
         Ok(try! {
             unsafe {
                 let mut zero: usize = 0;
@@ -71,21 +72,21 @@ impl API {
                     }).and_then(|_| {
                         match info {
                             cl::ContextInfoQuery::REFERENCE_COUNT => {
-                                Ok(cl::ContextInfo::ReferenceCount(info_ptr as cl::uint))
+                                Ok(ContextInfo::ReferenceCount(info_ptr as cl::uint))
                             },
                             cl::ContextInfoQuery::DEVICES => {
                                 let len = *info_size / size_of::<cl::uint>();
-                                Ok(cl::ContextInfo::Devices(
+                                Ok(ContextInfo::Devices(
                                     Vec::from_raw_parts(
                                         info_ptr as *mut cl::uint,
                                         len, len
                                 )))
                             },
                             cl::ContextInfoQuery::NUM_DEVICES => {
-                                Ok(cl::ContextInfo::NumDevices(info_ptr as cl::uint))
+                                Ok(ContextInfo::NumDevices(info_ptr as cl::uint))
                             },
                             cl::ContextInfoQuery::PROPERTIES => {
-                                Ok(cl::ContextInfo::ContextProperties(info_ptr as cl::context_properties))
+                                Ok(ContextInfo::ContextProperties(info_ptr as cl::context_properties))
                             }
                         }
                     })

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -91,7 +91,7 @@ impl API {
                                 Ok(ContextInfo::NumDevices(info_ptr as cl::uint))
                             },
                             cl::ContextInfoQuery::PROPERTIES => {
-                                Ok(ContextInfo::ContextProperties(info_ptr as cl::context_properties))
+                                Ok(ContextInfo::Properties(info_ptr as cl::context_properties))
                             }
                         }
                     })

--- a/src/frameworks/opencl/api/types.rs
+++ b/src/frameworks/opencl/api/types.rs
@@ -177,7 +177,7 @@ pub const CL_DEVICE_TYPE_CUSTOM:                        bitfield = 1 << 4;
 pub static CL_DEVICE_TYPE_ALL:                          bitfield = 0xFFFFFFFF;
 
 /* cl_device_info */
-pub const CL_DEVICE_TYPE:                               uint = 0x1000;
+pub const CL_DEVICE_TYPE:                                uint = 0x1000;
 pub static CL_DEVICE_VENDOR_ID:                          uint = 0x1001;
 pub static CL_DEVICE_MAX_COMPUTE_UNITS:                  uint = 0x1002;
 pub static CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS:           uint = 0x1003;
@@ -272,6 +272,28 @@ pub static CL_CONTEXT_DEVICES:                           uint = 0x1081;
 pub static CL_CONTEXT_PROPERTIES:                        uint = 0x1082;
 pub static CL_CONTEXT_NUM_DEVICES:                       uint = 0x1083;
 
+enum_from_primitive! {
+    /// OpenCL context info constants.
+    #[derive(PartialEq, Debug, Copy, Clone)]
+    #[repr(C)]
+    pub enum ContextInfoQuery {
+        REFERENCE_COUNT = 0x1080,
+        DEVICES = 0x1081,
+        PROPERTIES = 0x1082,
+        NUM_DEVICES = 0x1083
+    }
+}
+
+/// OpenCL context info constants.
+#[derive(PartialEq, Debug)]
+#[repr(C)]
+pub enum ContextInfo {
+    ReferenceCount(uint),
+    NumDevices(uint),
+    ContextProperties(context_properties),
+    Devices(Vec<uint>)
+}
+    
 /* cl_context_info + cl_context_properties */
 pub static CL_CONTEXT_PLATFORM:                          libc::intptr_t = 0x1084;
 

--- a/src/frameworks/opencl/api/types.rs
+++ b/src/frameworks/opencl/api/types.rs
@@ -177,7 +177,7 @@ pub const CL_DEVICE_TYPE_CUSTOM:                        bitfield = 1 << 4;
 pub static CL_DEVICE_TYPE_ALL:                          bitfield = 0xFFFFFFFF;
 
 /* cl_device_info */
-pub const CL_DEVICE_TYPE:                                uint = 0x1000;
+pub static CL_DEVICE_TYPE:                               uint = 0x1000;
 pub static CL_DEVICE_VENDOR_ID:                          uint = 0x1001;
 pub static CL_DEVICE_MAX_COMPUTE_UNITS:                  uint = 0x1002;
 pub static CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS:           uint = 0x1003;
@@ -282,16 +282,6 @@ enum_from_primitive! {
         PROPERTIES = 0x1082,
         NUM_DEVICES = 0x1083
     }
-}
-
-/// OpenCL context info constants.
-#[derive(PartialEq, Debug)]
-#[repr(C)]
-pub enum ContextInfo {
-    ReferenceCount(uint),
-    NumDevices(uint),
-    ContextProperties(context_properties),
-    Devices(Vec<uint>)
 }
     
 /* cl_context_info + cl_context_properties */

--- a/src/frameworks/opencl/api/types.rs
+++ b/src/frameworks/opencl/api/types.rs
@@ -73,7 +73,6 @@ pub struct buffer_region {
 }
 
 
-
 enum_from_primitive! {
 /// OpenCL error codes.
 #[derive(PartialEq, Debug)]
@@ -267,25 +266,14 @@ pub static CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE:       bitfield = 1;
 pub static CL_QUEUE_PROFILING_ENABLE:                    bitfield = 1 << 1;
 
 /* cl_context_info  */
-pub static CL_CONTEXT_REFERENCE_COUNT:                   uint = 0x1080;
-pub static CL_CONTEXT_DEVICES:                           uint = 0x1081;
-pub static CL_CONTEXT_PROPERTIES:                        uint = 0x1082;
-pub static CL_CONTEXT_NUM_DEVICES:                       uint = 0x1083;
+pub const CL_CONTEXT_REFERENCE_COUNT:                   uint = 0x1080;
+pub const CL_CONTEXT_DEVICES:                           uint = 0x1081;
+pub const CL_CONTEXT_PROPERTIES:                        uint = 0x1082;
+pub const CL_CONTEXT_NUM_DEVICES:                       uint = 0x1083;
 
-enum_from_primitive! {
-    /// OpenCL context info constants.
-    #[derive(PartialEq, Debug, Copy, Clone)]
-    #[repr(C)]
-    pub enum ContextInfoQuery {
-        REFERENCE_COUNT = 0x1080,
-        DEVICES = 0x1081,
-        PROPERTIES = 0x1082,
-        NUM_DEVICES = 0x1083
-    }
-}
-    
 /* cl_context_info + cl_context_properties */
-pub static CL_CONTEXT_PLATFORM:                          libc::intptr_t = 0x1084;
+pub const CL_CONTEXT_PLATFORM:                          libc::intptr_t = 0x1084;
+pub const CL_CONTEXT_INTEROP_USER_SYNC:                 libc::intptr_t = 0x1085;
 
 /* cl_command_queue_info */
 pub static CL_QUEUE_CONTEXT:                             uint = 0x1090;

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -12,6 +12,7 @@ use frameworks::native::device::Cpu;
 use std::any::Any;
 use std::{ptr, mem};
 use std::hash::{Hash, Hasher};
+use libc::c_void;
 
 #[derive(Debug, Clone)]
 /// Defines a OpenCL Context.
@@ -19,6 +20,19 @@ pub struct Context {
     id: isize,
     devices: Vec<Device>,
     queue: Option<Queue>
+}
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub struct ContextProperties {
+    /// Identifies a context's associated platform.
+    platform: u32,
+    /// Pointer to an ID3D10Device, as defined by the Microsoft Direct3D API.
+    d3d10_device: Option<*const c_void>,
+    // GLContext(), // OS dependent
+    // EGLContext, // EGLDisplay
+    // GLXDisplay, // GLXContent
+    // WGLHDC, // HDC (letter barf)
+    // CGLSharegroup // CGLShareGroupObj
 }
 
 /// OpenCL context info types. Each variant is returned from the same function,
@@ -35,15 +49,15 @@ pub enum ContextInfo {
     ///
     /// - CL_CONTEXT_PLATFORM
     /// - CL_CONTEXT_D3D10_DEVICE_KHR
-    /// - CL_GL_CONTEXT_KHR
-    /// - CL_EGL_CONTEXT_KHR
-    /// - CL_GLX_DISPLAY_KHR
-    /// - CL_WGL_HDC_KHR
-    /// - CL_CGL_SHAREGROUP_KHR
+    // - CL_GL_CONTEXT_KHR (OS-dependent)
+    // - CL_EGL_CONTEXT_KHR (OpenGL-ES context on embedded devices)
+    // - CL_GLX_DISPLAY_KHR (GL context on Linux)
+    // - CL_WGL_HDC_KHR (GL context on Windows)
+    // - CL_CGL_SHAREGROUP_KHR (GL context sharegroup on MacOS)
     ///
     /// Only the first property is required--the others may not be there
     /// depending on CL extensions.
-    ContextProperties(cl::context_properties),
+    Properties(ContextProperties),
     /// The devices (IDs) in the context.
     Devices(Vec<Device>)
 }

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -24,12 +24,11 @@ pub struct Context {
 /// OpenCL context info types. Each variant is returned from the same function,
 /// `get_context_info`.
 #[derive(PartialEq, Debug)]
-#[repr(C)]
 pub enum ContextInfo {
     /// Number of references to the context currently held.
-    ReferenceCount(cl::uint),
+    ReferenceCount(u32),
     /// Number of devices in the context.
-    NumDevices(cl::uint),
+    NumDevices(u32),
     /// The properties the context was configured with.
     ///
     /// These are:
@@ -46,7 +45,7 @@ pub enum ContextInfo {
     /// depending on CL extensions.
     ContextProperties(cl::context_properties),
     /// The devices (IDs) in the context.
-    Devices(Vec<cl::uint>)
+    Devices(Vec<Device>)
 }
 
 impl Context {

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -21,6 +21,34 @@ pub struct Context {
     queue: Option<Queue>
 }
 
+/// OpenCL context info types. Each variant is returned from the same function,
+/// `get_context_info`.
+#[derive(PartialEq, Debug)]
+#[repr(C)]
+pub enum ContextInfo {
+    /// Number of references to the context currently held.
+    ReferenceCount(cl::uint),
+    /// Number of devices in the context.
+    NumDevices(cl::uint),
+    /// The properties the context was configured with.
+    ///
+    /// These are:
+    ///
+    /// - CL_CONTEXT_PLATFORM
+    /// - CL_CONTEXT_D3D10_DEVICE_KHR
+    /// - CL_GL_CONTEXT_KHR
+    /// - CL_EGL_CONTEXT_KHR
+    /// - CL_GLX_DISPLAY_KHR
+    /// - CL_WGL_HDC_KHR
+    /// - CL_CGL_SHAREGROUP_KHR
+    ///
+    /// Only the first property is required--the others may not be there
+    /// depending on CL extensions.
+    ContextProperties(cl::context_properties),
+    /// The devices (IDs) in the context.
+    Devices(Vec<cl::uint>)
+}
+
 impl Context {
     /// Initializes a new OpenCL platform.
     pub fn new(devices: Vec<Device>) -> Result<Context, Error> {

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -3,7 +3,7 @@
 use device::{IDevice, MemorySync};
 use device::Error as DeviceError;
 use super::api::types as cl;
-use super::{API, Error, Device, Queue};
+use super::{API, Error, Device, Queue, Platform};
 use super::memory::*;
 #[cfg(feature = "native")]
 use frameworks::native::flatbox::FlatBox;
@@ -12,7 +12,6 @@ use frameworks::native::device::Cpu;
 use std::any::Any;
 use std::{ptr, mem};
 use std::hash::{Hash, Hasher};
-use libc::c_void;
 
 #[derive(Debug, Clone)]
 /// Defines a OpenCL Context.
@@ -22,22 +21,31 @@ pub struct Context {
     queue: Option<Queue>
 }
 
+/// The individual properties for `ContextInfo::Properties`
 #[derive(PartialEq, Debug, Clone, Copy)]
-pub struct ContextProperties {
+pub enum ContextProperties {
     /// Identifies a context's associated platform.
-    platform: u32,
-    /// Pointer to an ID3D10Device, as defined by the Microsoft Direct3D API.
-    d3d10_device: Option<*const c_void>,
-    // GLContext(), // OS dependent
-    // EGLContext, // EGLDisplay
-    // GLXDisplay, // GLXContent
-    // WGLHDC, // HDC (letter barf)
-    // CGLSharegroup // CGLShareGroupObj
+    Platform(Platform),
+    /// Does the user need to sync between frameworks manually (OpenCL 2.0 and later)
+    InteropUserSync(bool),
+}
+
+/// OpenCL context info constants, these ones are for the Query
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum ContextInfoQuery {
+    /// Number of references to the context currently held.
+    ReferenceCount,
+    /// Number of devices in the context.
+    NumDevices,
+    /// The properties the context was configured with.
+    Properties,
+    /// The devices (IDs) in the context.
+    Devices
 }
 
 /// OpenCL context info types. Each variant is returned from the same function,
 /// `get_context_info`.
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum ContextInfo {
     /// Number of references to the context currently held.
     ReferenceCount(u32),
@@ -49,15 +57,15 @@ pub enum ContextInfo {
     ///
     /// - CL_CONTEXT_PLATFORM
     /// - CL_CONTEXT_D3D10_DEVICE_KHR
-    // - CL_GL_CONTEXT_KHR (OS-dependent)
-    // - CL_EGL_CONTEXT_KHR (OpenGL-ES context on embedded devices)
-    // - CL_GLX_DISPLAY_KHR (GL context on Linux)
-    // - CL_WGL_HDC_KHR (GL context on Windows)
-    // - CL_CGL_SHAREGROUP_KHR (GL context sharegroup on MacOS)
+    /// - CL_GL_CONTEXT_KHR (OS-dependent)
+    /// - CL_EGL_CONTEXT_KHR (OpenGL-ES context on embedded devices)
+    /// - CL_GLX_DISPLAY_KHR (GL context on Linux)
+    /// - CL_WGL_HDC_KHR (GL context on Windows)
+    /// - CL_CGL_SHAREGROUP_KHR (GL context sharegroup on MacOS)
     ///
     /// Only the first property is required--the others may not be there
     /// depending on CL extensions.
-    Properties(ContextProperties),
+    Properties(Vec<ContextProperties>),
     /// The devices (IDs) in the context.
     Devices(Vec<Device>)
 }
@@ -92,6 +100,11 @@ impl Context {
             self.queue = Some(Queue::new(self, &self.hardwares()[0], None).unwrap());
             self.queue.as_mut().unwrap()
         }
+    }
+
+    /// Get certain parameters of the context, defined by `ContextInfoQuery`.
+    pub fn get_context_info(&self, query : ContextInfoQuery) -> Result<ContextInfo, Error> {
+        API::get_context_info(self.id as cl::context_id, query)
     }
 
     /// Returns the id as isize.

--- a/src/frameworks/opencl/device.rs
+++ b/src/frameworks/opencl/device.rs
@@ -49,7 +49,7 @@ impl PartialOrd for Version {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 /// Defines a OpenCL Device.
 ///
 /// Can later be transformed into a [Coaster hardware][hardware].

--- a/src/frameworks/opencl/platform.rs
+++ b/src/frameworks/opencl/platform.rs
@@ -2,7 +2,7 @@
 
 use super::api::types as cl;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 /// Defines a OpenCL Platform.
 pub struct Platform {
     id: isize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
 #![deny(missing_docs,
         missing_debug_implementations, missing_copy_implementations,
         trivial_casts, trivial_numeric_casts,
-        unused_import_braces, unused_qualifications)]
+        unused_import_braces)]
 
 #![cfg_attr(feature = "unstable_alloc", feature(alloc))]
 #[cfg(feature = "unstable_alloc")]


### PR DESCRIPTION
This has a few issues:

* unused_qualifications was removed, which I am not sure what it does or why it needed to be there in the first place, adding it causes `std::mem::size_of` to fail.
* Docstrings are still mostly garbage.
* Untested
