### PR TITLE
feat/opencl: getContextInfo implementation

### DIFF
--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -87,9 +87,9 @@ impl API {
                                 Ok(ContextInfo::ReferenceCount(reference_count))
                             },
                             cl::CL_CONTEXT_DEVICES => {
-                                let len = *info_size / size_of::<cl::uint>();
-                                let mut dev_ids : Vec<cl::uint> = Vec::new();
-                                let info_ptr : *mut cl::uint = info_ptr as *mut cl::uint;
+                                let len = *info_size / size_of::<cl::device_id>();
+                                let mut dev_ids : Vec<cl::device_id> = Vec::new();
+                                let info_ptr : *mut cl::device_id = info_ptr as *mut cl::device_id;
                                 for i in 0..len as isize {
                                     dev_ids.push(*info_ptr.offset(i));
                                 }

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -76,11 +76,16 @@ impl API {
                             },
                             cl::ContextInfoQuery::DEVICES => {
                                 let len = *info_size / size_of::<cl::uint>();
-                                Ok(ContextInfo::Devices(
-                                    Vec::from_raw_parts(
+                                let dev_ids = Vec::from_raw_parts(
                                         info_ptr as *mut cl::uint,
                                         len, len
-                                )))
+                                );
+                                Ok(ContextInfo::Devices(
+                                    dev_ids
+                                        .iter()
+                                        .map(|&id| Device::from_isize(id as isize))
+                                        .collect()
+                                ))
                             },
                             cl::ContextInfoQuery::NUM_DEVICES => {
                                 Ok(ContextInfo::NumDevices(info_ptr as cl::uint))

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -3,7 +3,8 @@
 //! At Coaster device can be understood as a synonym to OpenCL's context.
 
 use libc;
-use frameworks::opencl::{API, Error, Device};
+use frameworks::opencl::{API, Device, Error};
+use frameworks::opencl::context::ContextInfo;
 use super::types as cl;
 use super::ffi::*;
 use std::ptr;
@@ -56,7 +57,7 @@ impl API {
     pub fn get_context_info(
         context: cl::context_id,
         info: cl::ContextInfoQuery,
-    ) -> Result<cl::ContextInfo, Error> {
+    ) -> Result<ContextInfo, Error> {
         Ok(try! {
             unsafe {
                 let mut zero: usize = 0;
@@ -71,21 +72,21 @@ impl API {
                     }).and_then(|_| {
                         match info {
                             cl::ContextInfoQuery::REFERENCE_COUNT => {
-                                Ok(cl::ContextInfo::ReferenceCount(info_ptr as cl::uint))
+                                Ok(ContextInfo::ReferenceCount(info_ptr as cl::uint))
                             },
                             cl::ContextInfoQuery::DEVICES => {
                                 let len = *info_size / size_of::<cl::uint>();
-                                Ok(cl::ContextInfo::Devices(
+                                Ok(ContextInfo::Devices(
                                     Vec::from_raw_parts(
                                         info_ptr as *mut cl::uint,
                                         len, len
                                 )))
                             },
                             cl::ContextInfoQuery::NUM_DEVICES => {
-                                Ok(cl::ContextInfo::NumDevices(info_ptr as cl::uint))
+                                Ok(ContextInfo::NumDevices(info_ptr as cl::uint))
                             },
                             cl::ContextInfoQuery::PROPERTIES => {
-                                Ok(cl::ContextInfo::ContextProperties(info_ptr as cl::context_properties))
+                                Ok(ContextInfo::ContextProperties(info_ptr as cl::context_properties))
                             }
                         }
                     })

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -61,7 +61,7 @@ impl API {
         query: ContextInfoQuery ,
     ) -> Result<ContextInfo, Error> {
 
-        let mut info_name : cl::context_info = match query {
+        let info_name : cl::context_info = match query {
             ContextInfoQuery::ReferenceCount => cl::CL_CONTEXT_REFERENCE_COUNT,
             ContextInfoQuery::NumDevices => cl::CL_CONTEXT_NUM_DEVICES,
             ContextInfoQuery::Properties => cl::CL_CONTEXT_PROPERTIES,
@@ -89,9 +89,9 @@ impl API {
 		                        let len = *info_size / size_of::<cl::uint>();
 		                        let mut dev_ids : Vec<cl::uint> = Vec::new();
 		                        let info_ptr : *mut cl::uint = info_ptr as *mut cl::uint;
-				        for i in 0..len as isize {
-				            dev_ids.push(*info_ptr.offset(i));
-					}
+		                        for i in 0..len as isize {
+		                            dev_ids.push(*info_ptr.offset(i));
+		                        }
 		                        Ok(ContextInfo::Devices(
 		                            dev_ids
 		                                .iter()
@@ -103,35 +103,42 @@ impl API {
 		                        Ok(ContextInfo::NumDevices(info_ptr as u32))
 		                    },
 		                    cl::CL_CONTEXT_PROPERTIES => {
-		                        let mut v : Vec<ContextProperties> = vec!();
-		                        let mut start : *mut u8 = info_ptr as *mut u8;
-		                        let old : *mut u8 = start.clone();
-		                        loop {
-		                            let key : *mut cl::context_properties = start as *mut cl::context_properties;
-		                            let x = *key;
-		                            start = start.offset(std::mem::size_of::<cl::context_properties>() as isize);
-		                            match x {
+		                        let mut v : Vec<ContextProperties> = Vec::new();
+		                        let mut ptr : *mut u8 = info_ptr as *mut u8;
+		                        let mut total_decoded: isize = 0;
+		                        let info_size = *info_size as isize;
+		                        println!("{:?}", info_size);
+		                        while total_decoded < info_size {
+		                            // get the identifier and advance by identifier size count bytes
+		                            let identifier : *mut cl::context_properties = ptr as *mut cl::context_properties;
+		                            let identifier = *identifier;
+		                            ptr = ptr.offset(std::mem::size_of::<cl::context_properties>() as isize);
+		                            // depending on the identifier decode the per identifier payload/argument with the
+		                            // corresponding type
+		                            match identifier {
 		                                cl::CL_CONTEXT_PLATFORM => {
-		                                    let next : *const cl::platform_id = info_ptr  as *const cl::platform_id;
-		                                    let p = *next;
-		                                    start = start.offset(std::mem::size_of::<cl::platform_id>() as isize);
-		                                    v.push(ContextProperties::Platform(Platform::from_c(p)));
-
+		                                    let platform_id : *const cl::platform_id = info_ptr  as *const cl::platform_id;
+		                                    let platform_id = *platform_id;
+		                                    let size = std::mem::size_of::<cl::platform_id>() as isize;
+		                                    total_decoded += size;
+		                                    ptr = ptr.offset(size);
+		                                    v.push(ContextProperties::Platform(Platform::from_c(platform_id)));
 		                                },
 		                                cl::CL_CONTEXT_INTEROP_USER_SYNC => {
-		                                    let next : *const cl::boolean = info_ptr as *const cl::boolean;
-		                                    let ius = *next == 0;
-		                                    start = start.offset(std::mem::size_of::<cl::boolean>() as isize);
-		                                    v.push(ContextProperties::InteropUserSync(ius));
+		                                    let interop_user_sync : *const cl::boolean = info_ptr as *const cl::boolean;
+		                                    let interop_user_sync = *interop_user_sync == 0;
+		                                    let size = std::mem::size_of::<cl::boolean>() as isize;
+		                                    total_decoded += size;
+		                                    ptr = ptr.offset(size);
+		                                    v.push(ContextProperties::InteropUserSync(interop_user_sync));
 		                                },
+		                                0 => {
+		                                    break;
+		                                }
 		                                _ => {
 		                                    return Err(Error::Other("Unknown property"));
 		                                }
 		                            };
-		                            // TODO comparision operator?
-		                            if old.offset(*info_size as isize) == start {
-		                                break;
-		                            }
 		                        }
 		                        Ok(ContextInfo::Properties(v))
 		                    }

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -9,7 +9,6 @@ use super::types as cl;
 use super::ffi::*;
 use std::ptr;
 use std::mem::size_of;
-use std;
 
 impl API {
     /// Creates a OpenCL context.
@@ -113,14 +112,14 @@ impl API {
                                     // get the identifier and advance by identifier size count bytes
                                     let identifier : *mut cl::context_properties = ptr as *mut cl::context_properties;
                                     let identifier = *identifier;
-                                    ptr = ptr.offset(std::mem::size_of::<cl::context_properties>() as isize);
+                                    ptr = ptr.offset(size_of::<cl::context_properties>() as isize);
                                     // depending on the identifier decode the per identifier payload/argument with the
                                     // corresponding type
                                     match identifier {
                                         cl::CL_CONTEXT_PLATFORM => {
                                             let platform_id : *const cl::platform_id = info_ptr  as *const cl::platform_id;
                                             let platform_id = *platform_id;
-                                            let size = std::mem::size_of::<cl::platform_id>() as isize;
+                                            let size = size_of::<cl::platform_id>() as isize;
                                             total_decoded += size;
                                             ptr = ptr.offset(size);
                                             v.push(ContextProperties::Platform(Platform::from_c(platform_id)));
@@ -128,7 +127,7 @@ impl API {
                                         cl::CL_CONTEXT_INTEROP_USER_SYNC => {
                                             let interop_user_sync : *const cl::boolean = info_ptr as *const cl::boolean;
                                             let interop_user_sync = *interop_user_sync == 0;
-                                            let size = std::mem::size_of::<cl::boolean>() as isize;
+                                            let size = size_of::<cl::boolean>() as isize;
                                             total_decoded += size;
                                             ptr = ptr.offset(size);
                                             v.push(ContextProperties::InteropUserSync(interop_user_sync));

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -91,7 +91,7 @@ impl API {
                                 Ok(ContextInfo::NumDevices(info_ptr as cl::uint))
                             },
                             cl::ContextInfoQuery::PROPERTIES => {
-                                Ok(ContextInfo::ContextProperties(info_ptr as cl::context_properties))
+                                Ok(ContextInfo::Properties(info_ptr as cl::context_properties))
                             }
                         }
                     })

--- a/src/frameworks/opencl/api/context.rs
+++ b/src/frameworks/opencl/api/context.rs
@@ -109,7 +109,6 @@ impl API {
                                 let mut ptr : *mut u8 = info_ptr as *mut u8;
                                 let mut total_decoded: isize = 0;
                                 let info_size = *info_size as isize;
-                                println!("{:?}", info_size);
                                 while total_decoded < info_size {
                                     // get the identifier and advance by identifier size count bytes
                                     let identifier : *mut cl::context_properties = ptr as *mut cl::context_properties;

--- a/src/frameworks/opencl/api/types.rs
+++ b/src/frameworks/opencl/api/types.rs
@@ -177,7 +177,7 @@ pub const CL_DEVICE_TYPE_CUSTOM:                        bitfield = 1 << 4;
 pub static CL_DEVICE_TYPE_ALL:                          bitfield = 0xFFFFFFFF;
 
 /* cl_device_info */
-pub const CL_DEVICE_TYPE:                               uint = 0x1000;
+pub const CL_DEVICE_TYPE:                                uint = 0x1000;
 pub static CL_DEVICE_VENDOR_ID:                          uint = 0x1001;
 pub static CL_DEVICE_MAX_COMPUTE_UNITS:                  uint = 0x1002;
 pub static CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS:           uint = 0x1003;
@@ -272,6 +272,28 @@ pub static CL_CONTEXT_DEVICES:                           uint = 0x1081;
 pub static CL_CONTEXT_PROPERTIES:                        uint = 0x1082;
 pub static CL_CONTEXT_NUM_DEVICES:                       uint = 0x1083;
 
+enum_from_primitive! {
+    /// OpenCL context info constants.
+    #[derive(PartialEq, Debug, Copy, Clone)]
+    #[repr(C)]
+    pub enum ContextInfoQuery {
+        REFERENCE_COUNT = 0x1080,
+        DEVICES = 0x1081,
+        PROPERTIES = 0x1082,
+        NUM_DEVICES = 0x1083
+    }
+}
+
+/// OpenCL context info constants.
+#[derive(PartialEq, Debug)]
+#[repr(C)]
+pub enum ContextInfo {
+    ReferenceCount(uint),
+    NumDevices(uint),
+    ContextProperties(context_properties),
+    Devices(Vec<uint>)
+}
+    
 /* cl_context_info + cl_context_properties */
 pub static CL_CONTEXT_PLATFORM:                          libc::intptr_t = 0x1084;
 

--- a/src/frameworks/opencl/api/types.rs
+++ b/src/frameworks/opencl/api/types.rs
@@ -177,7 +177,7 @@ pub const CL_DEVICE_TYPE_CUSTOM:                        bitfield = 1 << 4;
 pub static CL_DEVICE_TYPE_ALL:                          bitfield = 0xFFFFFFFF;
 
 /* cl_device_info */
-pub const CL_DEVICE_TYPE:                                uint = 0x1000;
+pub static CL_DEVICE_TYPE:                               uint = 0x1000;
 pub static CL_DEVICE_VENDOR_ID:                          uint = 0x1001;
 pub static CL_DEVICE_MAX_COMPUTE_UNITS:                  uint = 0x1002;
 pub static CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS:           uint = 0x1003;
@@ -282,16 +282,6 @@ enum_from_primitive! {
         PROPERTIES = 0x1082,
         NUM_DEVICES = 0x1083
     }
-}
-
-/// OpenCL context info constants.
-#[derive(PartialEq, Debug)]
-#[repr(C)]
-pub enum ContextInfo {
-    ReferenceCount(uint),
-    NumDevices(uint),
-    ContextProperties(context_properties),
-    Devices(Vec<uint>)
 }
     
 /* cl_context_info + cl_context_properties */

--- a/src/frameworks/opencl/api/types.rs
+++ b/src/frameworks/opencl/api/types.rs
@@ -73,7 +73,6 @@ pub struct buffer_region {
 }
 
 
-
 enum_from_primitive! {
 /// OpenCL error codes.
 #[derive(PartialEq, Debug)]
@@ -267,25 +266,14 @@ pub static CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE:       bitfield = 1;
 pub static CL_QUEUE_PROFILING_ENABLE:                    bitfield = 1 << 1;
 
 /* cl_context_info  */
-pub static CL_CONTEXT_REFERENCE_COUNT:                   uint = 0x1080;
-pub static CL_CONTEXT_DEVICES:                           uint = 0x1081;
-pub static CL_CONTEXT_PROPERTIES:                        uint = 0x1082;
-pub static CL_CONTEXT_NUM_DEVICES:                       uint = 0x1083;
+pub const CL_CONTEXT_REFERENCE_COUNT:                   uint = 0x1080;
+pub const CL_CONTEXT_DEVICES:                           uint = 0x1081;
+pub const CL_CONTEXT_PROPERTIES:                        uint = 0x1082;
+pub const CL_CONTEXT_NUM_DEVICES:                       uint = 0x1083;
 
-enum_from_primitive! {
-    /// OpenCL context info constants.
-    #[derive(PartialEq, Debug, Copy, Clone)]
-    #[repr(C)]
-    pub enum ContextInfoQuery {
-        REFERENCE_COUNT = 0x1080,
-        DEVICES = 0x1081,
-        PROPERTIES = 0x1082,
-        NUM_DEVICES = 0x1083
-    }
-}
-    
 /* cl_context_info + cl_context_properties */
-pub static CL_CONTEXT_PLATFORM:                          libc::intptr_t = 0x1084;
+pub const CL_CONTEXT_PLATFORM:                          libc::intptr_t = 0x1084;
+pub const CL_CONTEXT_INTEROP_USER_SYNC:                 libc::intptr_t = 0x1085;
 
 /* cl_command_queue_info */
 pub static CL_QUEUE_CONTEXT:                             uint = 0x1090;

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -12,6 +12,7 @@ use frameworks::native::device::Cpu;
 use std::any::Any;
 use std::{ptr, mem};
 use std::hash::{Hash, Hasher};
+use libc::c_void;
 
 #[derive(Debug, Clone)]
 /// Defines a OpenCL Context.
@@ -19,6 +20,19 @@ pub struct Context {
     id: isize,
     devices: Vec<Device>,
     queue: Option<Queue>
+}
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub struct ContextProperties {
+    /// Identifies a context's associated platform.
+    platform: u32,
+    /// Pointer to an ID3D10Device, as defined by the Microsoft Direct3D API.
+    d3d10_device: Option<*const c_void>,
+    // GLContext(), // OS dependent
+    // EGLContext, // EGLDisplay
+    // GLXDisplay, // GLXContent
+    // WGLHDC, // HDC (letter barf)
+    // CGLSharegroup // CGLShareGroupObj
 }
 
 /// OpenCL context info types. Each variant is returned from the same function,
@@ -35,15 +49,15 @@ pub enum ContextInfo {
     ///
     /// - CL_CONTEXT_PLATFORM
     /// - CL_CONTEXT_D3D10_DEVICE_KHR
-    /// - CL_GL_CONTEXT_KHR
-    /// - CL_EGL_CONTEXT_KHR
-    /// - CL_GLX_DISPLAY_KHR
-    /// - CL_WGL_HDC_KHR
-    /// - CL_CGL_SHAREGROUP_KHR
+    // - CL_GL_CONTEXT_KHR (OS-dependent)
+    // - CL_EGL_CONTEXT_KHR (OpenGL-ES context on embedded devices)
+    // - CL_GLX_DISPLAY_KHR (GL context on Linux)
+    // - CL_WGL_HDC_KHR (GL context on Windows)
+    // - CL_CGL_SHAREGROUP_KHR (GL context sharegroup on MacOS)
     ///
     /// Only the first property is required--the others may not be there
     /// depending on CL extensions.
-    ContextProperties(cl::context_properties),
+    Properties(ContextProperties),
     /// The devices (IDs) in the context.
     Devices(Vec<Device>)
 }

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -24,12 +24,11 @@ pub struct Context {
 /// OpenCL context info types. Each variant is returned from the same function,
 /// `get_context_info`.
 #[derive(PartialEq, Debug)]
-#[repr(C)]
 pub enum ContextInfo {
     /// Number of references to the context currently held.
-    ReferenceCount(cl::uint),
+    ReferenceCount(u32),
     /// Number of devices in the context.
-    NumDevices(cl::uint),
+    NumDevices(u32),
     /// The properties the context was configured with.
     ///
     /// These are:
@@ -46,7 +45,7 @@ pub enum ContextInfo {
     /// depending on CL extensions.
     ContextProperties(cl::context_properties),
     /// The devices (IDs) in the context.
-    Devices(Vec<cl::uint>)
+    Devices(Vec<Device>)
 }
 
 impl Context {

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -21,6 +21,34 @@ pub struct Context {
     queue: Option<Queue>
 }
 
+/// OpenCL context info types. Each variant is returned from the same function,
+/// `get_context_info`.
+#[derive(PartialEq, Debug)]
+#[repr(C)]
+pub enum ContextInfo {
+    /// Number of references to the context currently held.
+    ReferenceCount(cl::uint),
+    /// Number of devices in the context.
+    NumDevices(cl::uint),
+    /// The properties the context was configured with.
+    ///
+    /// These are:
+    ///
+    /// - CL_CONTEXT_PLATFORM
+    /// - CL_CONTEXT_D3D10_DEVICE_KHR
+    /// - CL_GL_CONTEXT_KHR
+    /// - CL_EGL_CONTEXT_KHR
+    /// - CL_GLX_DISPLAY_KHR
+    /// - CL_WGL_HDC_KHR
+    /// - CL_CGL_SHAREGROUP_KHR
+    ///
+    /// Only the first property is required--the others may not be there
+    /// depending on CL extensions.
+    ContextProperties(cl::context_properties),
+    /// The devices (IDs) in the context.
+    Devices(Vec<cl::uint>)
+}
+
 impl Context {
     /// Initializes a new OpenCL platform.
     pub fn new(devices: Vec<Device>) -> Result<Context, Error> {

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -45,7 +45,7 @@ pub enum ContextInfoQuery {
 
 /// OpenCL context info types. Each variant is returned from the same function,
 /// `get_context_info`.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 pub enum ContextInfo {
     /// Number of references to the context currently held.
     ReferenceCount(u32),

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -3,7 +3,7 @@
 use device::{IDevice, MemorySync};
 use device::Error as DeviceError;
 use super::api::types as cl;
-use super::{API, Error, Device, Queue};
+use super::{API, Error, Device, Queue, Platform};
 use super::memory::*;
 #[cfg(feature = "native")]
 use frameworks::native::flatbox::FlatBox;
@@ -12,7 +12,6 @@ use frameworks::native::device::Cpu;
 use std::any::Any;
 use std::{ptr, mem};
 use std::hash::{Hash, Hasher};
-use libc::c_void;
 
 #[derive(Debug, Clone)]
 /// Defines a OpenCL Context.
@@ -22,22 +21,31 @@ pub struct Context {
     queue: Option<Queue>
 }
 
+/// The individual properties for `ContextInfo::Properties`
 #[derive(PartialEq, Debug, Clone, Copy)]
-pub struct ContextProperties {
+pub enum ContextProperties {
     /// Identifies a context's associated platform.
-    platform: u32,
-    /// Pointer to an ID3D10Device, as defined by the Microsoft Direct3D API.
-    d3d10_device: Option<*const c_void>,
-    // GLContext(), // OS dependent
-    // EGLContext, // EGLDisplay
-    // GLXDisplay, // GLXContent
-    // WGLHDC, // HDC (letter barf)
-    // CGLSharegroup // CGLShareGroupObj
+    Platform(Platform),
+    /// Does the user need to sync between frameworks manually (OpenCL 2.0 and later)
+    InteropUserSync(bool),
+}
+
+/// OpenCL context info constants, these ones are for the Query
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum ContextInfoQuery {
+    /// Number of references to the context currently held.
+    ReferenceCount,
+    /// Number of devices in the context.
+    NumDevices,
+    /// The properties the context was configured with.
+    Properties,
+    /// The devices (IDs) in the context.
+    Devices
 }
 
 /// OpenCL context info types. Each variant is returned from the same function,
 /// `get_context_info`.
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum ContextInfo {
     /// Number of references to the context currently held.
     ReferenceCount(u32),
@@ -49,15 +57,15 @@ pub enum ContextInfo {
     ///
     /// - CL_CONTEXT_PLATFORM
     /// - CL_CONTEXT_D3D10_DEVICE_KHR
-    // - CL_GL_CONTEXT_KHR (OS-dependent)
-    // - CL_EGL_CONTEXT_KHR (OpenGL-ES context on embedded devices)
-    // - CL_GLX_DISPLAY_KHR (GL context on Linux)
-    // - CL_WGL_HDC_KHR (GL context on Windows)
-    // - CL_CGL_SHAREGROUP_KHR (GL context sharegroup on MacOS)
+    /// - CL_GL_CONTEXT_KHR (OS-dependent)
+    /// - CL_EGL_CONTEXT_KHR (OpenGL-ES context on embedded devices)
+    /// - CL_GLX_DISPLAY_KHR (GL context on Linux)
+    /// - CL_WGL_HDC_KHR (GL context on Windows)
+    /// - CL_CGL_SHAREGROUP_KHR (GL context sharegroup on MacOS)
     ///
     /// Only the first property is required--the others may not be there
     /// depending on CL extensions.
-    Properties(ContextProperties),
+    Properties(Vec<ContextProperties>),
     /// The devices (IDs) in the context.
     Devices(Vec<Device>)
 }
@@ -92,6 +100,11 @@ impl Context {
             self.queue = Some(Queue::new(self, &self.hardwares()[0], None).unwrap());
             self.queue.as_mut().unwrap()
         }
+    }
+
+    /// Get certain parameters of the context, defined by `ContextInfoQuery`.
+    pub fn get_context_info(&self, query : ContextInfoQuery) -> Result<ContextInfo, Error> {
+        API::get_context_info(self.id as cl::context_id, query)
     }
 
     /// Returns the id as isize.

--- a/src/frameworks/opencl/device.rs
+++ b/src/frameworks/opencl/device.rs
@@ -59,7 +59,7 @@ impl Version {
 #[derive(Debug, Clone)]
 /// Defines a OpenCL Device.
 ///
-/// Can later be transformed into a [Collenchyma hardware][hardware].
+/// Can later be transformed into a [Coaster hardware][hardware].
 /// [hardware]: ../../hardware/index.html
 pub struct Device {
     id: isize,

--- a/src/frameworks/opencl/device.rs
+++ b/src/frameworks/opencl/device.rs
@@ -56,7 +56,7 @@ impl Version {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 /// Defines a OpenCL Device.
 ///
 /// Can later be transformed into a [Coaster hardware][hardware].

--- a/src/frameworks/opencl/platform.rs
+++ b/src/frameworks/opencl/platform.rs
@@ -2,7 +2,7 @@
 
 use super::api::types as cl;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 /// Defines a OpenCL Platform.
 pub struct Platform {
     id: isize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
 #![deny(missing_docs,
         missing_debug_implementations, missing_copy_implementations,
         trivial_casts, trivial_numeric_casts,
-        unused_import_braces, unused_qualifications)]
+        unused_import_braces)]
 
 #![cfg_attr(feature = "unstable_alloc", feature(alloc))]
 #[cfg(feature = "unstable_alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
 #![deny(missing_docs,
         missing_debug_implementations, missing_copy_implementations,
         trivial_casts, trivial_numeric_casts,
-        unused_import_braces)]
+        unused_import_braces, unused_qualifications)]
 
 #![cfg_attr(feature = "unstable_alloc", feature(alloc))]
 #[cfg(feature = "unstable_alloc")]

--- a/tests/framework_opencl_specs.rs
+++ b/tests/framework_opencl_specs.rs
@@ -38,12 +38,12 @@ mod framework_opencl_spec {
     }
 
     #[test]
-    fn it_querries_context_info() {
+    fn it_queries_context_info() {
         let frm = OpenCL::new();
         let ctx = frm.new_device(&frm.hardwares()[0..1]).unwrap();
         println!("ReferenceCount: {:?}", ctx.get_context_info(ContextInfoQuery::ReferenceCount));
         println!("NumDevices: {:?}", ctx.get_context_info(ContextInfoQuery::NumDevices));
-        println!("Properties: {:?}", ctx.get_context_info(ContextInfoQuery::Properties));
         println!("Devices: {:?}", ctx.get_context_info(ContextInfoQuery::Devices));
+        println!("Properties: {:?}", ctx.get_context_info(ContextInfoQuery::Properties));
 	}
 }

--- a/tests/framework_opencl_specs.rs
+++ b/tests/framework_opencl_specs.rs
@@ -7,6 +7,7 @@ mod framework_opencl_spec {
     use co::prelude::*;
     use co::frameworks::opencl::memory::*;
     use co::frameworks::opencl::queue::*;
+    use co::frameworks::opencl::context::*;
 
     #[test]
     fn it_works() {
@@ -35,4 +36,14 @@ mod framework_opencl_spec {
         let ctx = frm.new_device(&frm.hardwares()[0..1]).unwrap();
         Queue::new(&ctx, &frm.hardwares()[0..1][0], None).unwrap();
     }
+
+    #[test]
+    fn it_querries_context_info() {
+        let frm = OpenCL::new();
+        let ctx = frm.new_device(&frm.hardwares()[0..1]).unwrap();
+        println!("ReferenceCount: {:?}", ctx.get_context_info(ContextInfoQuery::ReferenceCount));
+        println!("NumDevices: {:?}", ctx.get_context_info(ContextInfoQuery::NumDevices));
+        println!("Properties: {:?}", ctx.get_context_info(ContextInfoQuery::Properties));
+        println!("Devices: {:?}", ctx.get_context_info(ContextInfoQuery::Devices));
+	}
 }


### PR DESCRIPTION
* [x] compiles
* [x] Implement tests
* [x] investigate: `unused_qualifications` was removed, which I am not sure what it does or why it needed to be there in the first place, adding it causes `std::mem::size_of` to fail
* [x] meaningful docstrings

